### PR TITLE
convert to packaged version of rancid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.swp
+ci/vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache \
       git \
       man man-pages \
       mdocml-apropos \
+      perl \
+      perl-socket6 \
     && apk add --no-cache --virtual .builddeps \
       alpine-sdk \
       autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.6
 # Use less to view man-pages since busybox `more' lacks the -s option.
 ENV PAGER=less
 
+ARG VERSION
+ARG RELEASE
+
 # Install dependencies.
 RUN apk add --no-cache \
       bash \
@@ -12,7 +15,7 @@ RUN apk add --no-cache \
       mdocml-apropos \
       perl \
       perl-socket6 \
-      "rancid=3.6.1-r0" \
+      "rancid=${VERSION}-${RELEASE}" \
       rancid-doc \
       && \
     :

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,19 @@ VOLUME ["/var/rancid", "/usr/local/rancid/var"]
 
 # `docker run' starts bash by default.
 CMD ["/bin/sh"]
+
+# These args and labels go last in the Dockerfile so
+# we do not bust the docker build cache for local builds.
+ARG CI_BUILD_URL
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL \
+    io.github.jumanjiman.ci-build-url=${CI_BUILD_URL} \
+    io.github.jumanjiman.version=${VERSION}-${RELEASE} \
+    io.github.jumanjiman.build-date=${BUILD_DATE} \
+    io.github.jumanjiman.vcs-ref=${VCS_REF} \
+    io.github.jumanjiman.license="MIT" \
+    io.github.jumanjiman.docker.dockerfile="/Dockerfile" \
+    io.github.jumanjiman.vcs-type="Git" \
+    io.github.jumanjiman.vcs-url="https://github.com/jumanjihouse/docker-rancid-git.git"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,39 +12,20 @@ RUN apk add --no-cache \
       mdocml-apropos \
       perl \
       perl-socket6 \
-    && apk add --no-cache --virtual .builddeps \
-      alpine-sdk \
-      autoconf \
-      automake \
-      gcc \
-      make \
-    && adduser -D -s /bin/sh rancid \
-    && \
-    cd /usr/bin && \
-    ln -s aclocal aclocal-1.14 && \
-    ln -s automake automake-1.14 && \
-    cd /root && \
-    git clone https://github.com/dotwaffle/rancid-git.git && \
-    cd rancid-git && \
-    ./configure \
-      --mandir=/usr/local/share/man \
-      --sysconfdir=/etc/rancid \
-      --bindir=/usr/bin/ \
-      --enable-conf-install \
+      "rancid=3.6.1-r0" \
+      rancid-doc \
       && \
-    make install && \
-    rm -fr /root/rancid-git && \
-    apk del --purge .builddeps
+    :
 
 # Update mandb so `man -k rancid' works.
 RUN makewhatis
 
 # Container starts as user "rancid" in home dir.
 USER rancid
-WORKDIR /home/rancid
+WORKDIR /var/rancid
 
 # Docker ignores files in these dirs.
-VOLUME ["/home/rancid", "/usr/local/rancid/var"]
+VOLUME ["/var/rancid", "/usr/local/rancid/var"]
 
 # `docker run' starts bash by default.
 CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Run a container with bash from the built image:
 License
 -------
 
-See LICENSE in this repo.
+See [`LICENSE`](LICENSE) in this repo.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Build this image locally on a host with Docker:
 
 Run a container with bash from the built image:
 
-    docker run --rm -it rancid-git
+    docker run --rm -it rancid
 
 
 License

--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ Run a container with bash from the built image:
     docker run --rm -it jumanjiman/rancid
 
 
+### Test
+
+We use circleci to build, test, and publish the image to Docker hub.
+We use [BATS](https://github.com/sstephenson/bats) to run the test harness.
+
+Run the tests locally:
+
+    ci/test
+
+BATS output resembles:
+
+    ✓ image exists
+    ✓ tagged image exists - optimistic
+    ✓ tagged image exists - pessimistic
+    ✓ rancid -h shows help
+    ✓ rancid is the expected version
+    - ci-build-url label is present (skipped: This test runs only on circleci)
+
+    6 tests, 0 failures, 1 skipped
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,11 @@ rancid-git on Alpine Linux
 Overview
 --------
 
-Demonstrate one way to build `rancid-git`.
-
-
-Related projects
-----------------
-
-* [rancid-git](https://github.com/dotwaffle/rancid-git)
-* [docker-rancid-git-centos6](https://github.com/jumanjihouse/docker-rancid-git-centos6)
+Provide [`rancid`](http://www.shrubbery.net/rancid/),
+the Really Awesome New Cisco confIg Differ,
+with git support in a smallish container.
+RANCID monitors a device's configuration, including software and hardware,
+and uses CVS, Subversion, or Git to maintain history of changes.
 
 
 How-to

--- a/README.md
+++ b/README.md
@@ -14,6 +14,32 @@ and uses CVS, Subversion, or Git to maintain history of changes.
 How-to
 ------
 
+### Pull an already-built image
+
+    docker pull jumanjiman/rancid
+
+
+### Tags
+
+We provide multiple tags:
+
+* optimistic:  `jumanjiman/rancid:latest`
+* pessimistic: `jumanjiman/rancid:<version>_<builddate>_git_<hash>`
+
+Example:
+
+    jumanjiman/rancid:3.6.1-r0_20170702T1659_git_6fead99
+                      ^^^^^^^^ ^^^^^^^^^^^^^     ^^^^^^^
+                          |         |              |
+                          |         |              +--> hash from this git repo
+                          |         |
+                          |         +-----------------> build date and time
+                          |
+                          +---------------------------> version of rancid
+
+
+### Build locally
+
 Build this image locally on a host with Docker:
 
     git clone https://github.com/jumanjihouse/docker-rancid-git.git
@@ -22,7 +48,7 @@ Build this image locally on a host with Docker:
 
 Run a container with bash from the built image:
 
-    docker run --rm -it rancid
+    docker run --rm -it jumanjiman/rancid
 
 
 License

--- a/ci/build
+++ b/ci/build
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e
+set -u
+
+cat > ci/vars <<EOF
+export VERSION=3.6.1
+export RELEASE=r0
+EOF
+. ci/vars
 
 docker-compose build

--- a/ci/build
+++ b/ci/build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-docker build --rm -t rancid .
+docker-compose build

--- a/ci/build
+++ b/ci/build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-docker build --rm -t rancid-git .
+docker build --rm -t rancid .

--- a/ci/build
+++ b/ci/build
@@ -5,6 +5,9 @@ set -u
 cat > ci/vars <<EOF
 export VERSION=3.6.1
 export RELEASE=r0
+export BUILD_DATE=$(date +%Y%m%dT%H%M)
+export VCS_REF=$(git rev-parse --short HEAD)
+export TAG=\${VERSION}-\${RELEASE}_\${BUILD_DATE}_git_\${VCS_REF}
 EOF
 . ci/vars
 

--- a/ci/publish
+++ b/ci/publish
@@ -1,2 +1,9 @@
 #!/bin/sh
 set -e
+set -u
+. ci/vars
+
+docker login -u ${user} -p ${pass}
+docker-compose push rancid_tag_pessimistic
+docker-compose push rancid_tag_optimistic
+docker logout

--- a/ci/test
+++ b/ci/test
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e
+set -u
+. ci/vars
 
 bats test/*.bats

--- a/ci/test
+++ b/ci/test
@@ -1,2 +1,4 @@
 #!/bin/sh
 set -e
+
+bats test/*.bats

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,9 @@ services:
     image: rancid
     build:
       context: ./
+      args:
+        - VERSION
+        - RELEASE
     stdin_open: true
     tty: true
     read_only: true
@@ -13,3 +16,8 @@ services:
     <<: *defaults
     entrypoint: rancid
     command: -h
+
+  version:
+    <<: *defaults
+    entrypoint: rancid
+    command: -V

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,9 @@ services:
       args:
         - VERSION
         - RELEASE
+        - BUILD_DATE
+        - VCS_REF
+        - CI_BUILD_URL=${CIRCLE_BUILD_URL}
     stdin_open: true
     tty: true
     read_only: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  rancid: &defaults
+    image: rancid
+    build:
+      context: ./
+    stdin_open: true
+    tty: true
+    read_only: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,14 @@ services:
     mem_limit: 512M
     shm_size: 32M
 
+  rancid_tag_pessimistic:
+    <<: *defaults
+    image: jumanjiman/rancid:${TAG}
+
+  rancid_tag_optimistic:
+    <<: *defaults
+    image: jumanjiman/rancid:latest
+
   help:
     <<: *defaults
     entrypoint: rancid

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,8 @@ services:
     stdin_open: true
     tty: true
     read_only: true
+
+  help:
+    <<: *defaults
+    entrypoint: rancid
+    command: -h

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,12 @@ services:
     stdin_open: true
     tty: true
     read_only: true
+    cap_drop:
+      - all
+    pids_limit: 30
+    cpu_shares: 1023
+    mem_limit: 512M
+    shm_size: 32M
 
   help:
     <<: *defaults

--- a/test/05_basics.bats
+++ b/test/05_basics.bats
@@ -22,3 +22,13 @@
   output=$(docker-compose run version 2> /dev/null)
   [[ ${output} =~ ^rancid\ +${VERSION} ]]
 }
+
+@test "ci-build-url label is present" {
+  if [[ -z ${CIRCLE_BUILD_URL} ]]; then
+    skip "This test runs only on circleci"
+  fi
+  run docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      jumanjiman/rancid
+  [[ ${output} =~ circleci.com ]]
+}

--- a/test/05_basics.bats
+++ b/test/05_basics.bats
@@ -7,3 +7,8 @@
   output=$(docker-compose run help 2> /dev/null || :)
   [[ ${output} =~ ^rancid.*-.*h ]]
 }
+
+@test "rancid is the expected version" {
+  output=$(docker-compose run version 2> /dev/null)
+  [[ ${output} =~ ^rancid\ +${VERSION} ]]
+}

--- a/test/05_basics.bats
+++ b/test/05_basics.bats
@@ -1,0 +1,9 @@
+@test "image exists" {
+  run docker images --format='{{ .Repository }}' rancid
+  [[ ${output} =~ ^rancid$ ]]
+}
+
+@test "rancid -h shows help" {
+  output=$(docker-compose run help 2> /dev/null || :)
+  [[ ${output} =~ ^rancid.*-.*h ]]
+}

--- a/test/05_basics.bats
+++ b/test/05_basics.bats
@@ -3,6 +3,16 @@
   [[ ${output} =~ ^rancid$ ]]
 }
 
+@test "tagged image exists - optimistic" {
+  run docker images --format='{{ .Repository }} {{ .Tag }}' jumanjiman/rancid:latest
+  [[ ${output} =~ ^jumanjiman/rancid\ latest$ ]]
+}
+
+@test "tagged image exists - pessimistic" {
+  run docker images --format='{{ .Tag }}' jumanjiman/rancid
+  [[ ${output} =~ ^${VERSION}-${RELEASE}_.*_git_.* ]]
+}
+
 @test "rancid -h shows help" {
   output=$(docker-compose run help 2> /dev/null || :)
   [[ ${output} =~ ^rancid.*-.*h ]]


### PR DESCRIPTION
The upstream rancid now supports git, so it's no longer necessary to build dotwaffle/rancid-git