### PR TITLE
make it easier to update the base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ jobs:
             ci/build
 
       - run:
+          name: Tag the image and add metadata
+          command: |
+            ci/tag
+
+      - run:
           name: Test the image
           command: |
             ci/test

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+# https://yamllint.readthedocs.io/en/latest/configuration.html
+extends: default
+
+# https://yamllint.readthedocs.io/en/latest/configuration.html#ignoring-paths
+rules:
+  line-length:
+    ignore: |
+      docker-compose-metadata.yaml

--- a/ci/05_basics.bats
+++ b/ci/05_basics.bats
@@ -15,17 +15,12 @@
 
 @test "tagged image exists - pessimistic" {
   run docker images --format='{{ .Tag }}' jumanjiman/rancid
-  [[ ${output} =~ ^${RANCID_VERSION}-${RANCID_RELEASE}_.*_git_.* ]]
+  [[ ${output} =~ ^${VERSION}_.*_git_.* ]]
 }
 
 @test "rancid -h shows help" {
   run docker-compose run help
   [[ ${output} =~ rancid.*-.*h ]]
-}
-
-@test "rancid is the expected version" {
-  run docker-compose run version
-  [[ ${output} =~ rancid\ +${RANCID_VERSION} ]]
 }
 
 @test "ci-build-url label is present" {

--- a/ci/build
+++ b/ci/build
@@ -6,18 +6,6 @@ set -o pipefail
 # Build docker image(s). Invoke as "ci/build" from the root of the git repo.
 ################################################################################
 
-cat >ci/vars <<EOF
-#-------------------------------------------------------------------------------
-# This file is created by ci/build and never checked into version control.
-# It is sourced by various ci scripts.
-#-------------------------------------------------------------------------------
-declare -rx RANCID_VERSION=3.8
-declare -rx RANCID_RELEASE=r2
-declare -rx BUILD_DATE=$(date +%Y%m%dT%H%M)
-declare -rx VCS_REF=$(git rev-parse --short HEAD)
-declare -rx TAG=\${RANCID_VERSION}-\${RANCID_RELEASE}_\${BUILD_DATE}_git_\${VCS_REF}
-EOF
-. ci/vars
 . ci/functions.sh
 
 docker-compose build

--- a/ci/publish
+++ b/ci/publish
@@ -11,8 +11,7 @@ set -o pipefail
 
 # shellcheck disable=SC2154
 docker login -u "${user}" -p "${pass}"
-docker-compose push rancid_tag_pessimistic
-docker-compose push rancid_tag_optimistic
+docker-compose -f docker-compose-metadata.yaml push
 docker logout
 
 curl -X POST 'https://hooks.microbadger.com/images/jumanjiman/rancid/QTyTWSknCxMR0T83yntDU-ubELY='

--- a/ci/tag
+++ b/ci/tag
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+################################################################################
+# Tag images.
+################################################################################
+
+cat >ci/vars <<EOF
+#-------------------------------------------------------------------------------
+# ci/vars is created by ci/tag and never checked into version control.
+#-------------------------------------------------------------------------------
+declare -rx VERSION=$(docker-compose run version 2>/dev/null | grep -o '[0-9a-zA-Z._\-]*')
+declare -rx BUILD_DATE=$(date +%Y%m%dT%H%M)
+declare -rx VCS_REF=$(git rev-parse --short HEAD)
+declare -rx TAG=\${VERSION}_\${BUILD_DATE}_git_\${VCS_REF}
+EOF
+
+. ci/vars
+. ci/functions.sh
+
+docker-compose -f docker-compose-metadata.yaml build

--- a/docker-compose-metadata.yaml
+++ b/docker-compose-metadata.yaml
@@ -1,0 +1,24 @@
+---
+version: '2.1'
+
+services:
+  rancid-tagged: &tagged
+    image: jumanjiman/rancid:${TAG}
+    build:
+      context: src/
+      labels:
+        - io.github.jumanjiman.ci-build-url=${CI_BUILD_URL}
+        - io.github.jumanjiman.version=${VERSION}
+        - io.github.jumanjiman.build-date=${BUILD_DATE}
+        - io.github.jumanjiman.vcs-ref=${VCS_REF}
+        - io.github.jumanjiman.name=jumanjiman/rancid
+        - io.github.jumanjiman.description=Really Awesome New Cisco confIg Differ
+        - io.github.jumanjiman.url=https://github.com/jumanjihouse/docker-rancid-git
+        - io.github.jumanjiman.license=MIT
+        - io.github.jumanjiman.docker.dockerfile=/src/Dockerfile
+        - io.github.jumanjiman.vcs-type=Git
+        - io.github.jumanjiman.vcs-url=https://github.com/jumanjihouse/docker-rancid-git.git
+
+  rancid-latest:
+    <<: *tagged
+    image: jumanjiman/rancid

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,12 +6,6 @@ services:
     image: rancid
     build:
       context: src/
-      args:
-        - RANCID_VERSION
-        - RANCID_RELEASE
-        - BUILD_DATE
-        - VCS_REF
-        - CI_BUILD_URL=${CIRCLE_BUILD_URL}
     stdin_open: true
     tty: true
     read_only: true
@@ -22,20 +16,15 @@ services:
     mem_limit: 512M
     shm_size: 32M
 
-  rancid_tag_pessimistic:
-    <<: *defaults
-    image: jumanjiman/rancid:${TAG}
-
-  rancid_tag_optimistic:
-    <<: *defaults
-    image: jumanjiman/rancid:latest
-
   help:
     <<: *defaults
     entrypoint: rancid
     command: -h
 
   version:
-    <<: *defaults
-    entrypoint: rancid
-    command: -V
+    image: rancid
+    entrypoint:
+      - sh
+    command:
+      - -c
+      - "apk policy rancid 2>/dev/null | tail -n +2 | head -1 | tr -d ' :'"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,9 +3,6 @@ FROM alpine:3.9
 # Use less to view man-pages since busybox `more' lacks the -s option.
 ENV PAGER=less
 
-ARG RANCID_VERSION
-ARG RANCID_RELEASE
-
 # Install dependencies.
 RUN apk add --no-cache \
       bash \
@@ -16,7 +13,7 @@ RUN apk add --no-cache \
       openssh-client \
       perl \
       perl-socket6 \
-      "rancid=${RANCID_VERSION}-${RANCID_RELEASE}" \
+      rancid \
       rancid-doc \
       && \
     :
@@ -33,19 +30,3 @@ VOLUME ["/var/rancid", "/usr/local/rancid/var"]
 
 # `docker run' starts bash by default.
 CMD ["/bin/sh"]
-
-# These args and labels go last in the Dockerfile so
-# we do not bust the docker build cache for local builds.
-ARG CI_BUILD_URL
-ARG BUILD_DATE
-ARG VCS_REF
-
-LABEL \
-    io.github.jumanjiman.ci-build-url=${CI_BUILD_URL} \
-    io.github.jumanjiman.version=${RANCID_VERSION}-${RANCID_RELEASE} \
-    io.github.jumanjiman.build-date=${BUILD_DATE} \
-    io.github.jumanjiman.vcs-ref=${VCS_REF} \
-    io.github.jumanjiman.license="MIT" \
-    io.github.jumanjiman.docker.dockerfile="/src/Dockerfile" \
-    io.github.jumanjiman.vcs-type="Git" \
-    io.github.jumanjiman.vcs-url="https://github.com/jumanjihouse/docker-rancid-git.git"


### PR DESCRIPTION
Impact of this change
---------------------

- Renovate-bot can submit PRs to update the base image, and
  the version of freeradius gets updated automatically.

- The version scheme of the built image remains the same:
  `${VERSION}-${BUILD_DATE}-git-${HASH}`
  Users can continue to rely on explicit information in the tag.

- The image metadata (labels) is unaffected.
  Users can continue to rely on info in image labels.

Details of the change
---------------------

Before this commit, to update the base image is a 2-step process.
1. Lookup the most recent base image version and update Dockerfile.
2. Lookup the version of rancid is in the Alpine base image version
   and update `ci/build`.

After this commit, to update the base image is a 1-step process.
1. Lookup the most recent base image version and update Dockerfile.

Build installs whatever version of rancid is in the base image
and tags the image with the version of rancid that was installed.